### PR TITLE
Support pushover alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,19 @@ The Coinbase Pro API Key will need a minimum of 'View' and 'Trade' permissions. 
 | Buy-Amount | Integer | The amount of crypto to buy, specified in your currency.<br />Example: Specifying `20` and `BTC-USD` will buy 20 USD worth of BTC. | Yes |
 | | | | |
 | **Alerts** |  |  |  |
-| Alerts-Enabled | Boolean | Enables sending buy and funding alerts to Discord. | Yes |
-| Discord-Webhook | String | The webhook URL you create in your Discord server. | If Alerts-Enabled is set to `true` |
+| Alert-Channel | String | Enables sending alert messages to Discord or Pushover.<br />Available Options: `discord`, `pushover` or leave empty for no notifications. | Yes |
+| Discord-Webhook | String | The webhook URL you create in your Discord server. | If Alert-Channel is set to `discord` |
+| Pushover-API-Token | String | Pushover API Token. | If Alert-Channel is set to `pushover` |
+| Pushover-User-Key | String | Pushover user key. | If Alert-Channel is set to `pushover` |
 
-## Discord Alerts
+## Alerts
+### Discord
 
 You can have alerts about funding and buys sent to Discord via a Webhook. See this [Discord support article](https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks) for how to setup a Webhook.
+
+### Pushover
+You can have alerts about funding and buys sent via the Pushover push notification service.<br />
+[What is Pushover and how do I use it?](https://support.pushover.net/i7-what-is-pushover-and-how-do-i-use-it)
 
 ## Docker Container
 

--- a/config.example.json
+++ b/config.example.json
@@ -35,7 +35,7 @@
     ],
     "Alerts" : [
         {
-            "Alerts-Channel" : "discord",
+            "Alert-Channel" : "discord",
             "Discord-Webhook" : "DISCORD_WEBHOOK_URL",
             "Pushover-API-Token": "PUSHOVER_API_TOKEN",
             "Pushover-User-Key": "PUSHOVER_USER_KEY"

--- a/config.example.json
+++ b/config.example.json
@@ -35,8 +35,10 @@
     ],
     "Alerts" : [
         {
-            "Alerts-Enabled" : true,
-            "Discord-Webhook" : "DISCORD_WEBHOOK_URL"
+            "Alerts-Channel" : "discord",
+            "Discord-Webhook" : "DISCORD_WEBHOOK_URL",
+            "Pushover-API-Token": "PUSHOVER_API_TOKEN",
+            "Pushover-User-Key": "PUSHOVER_USER_KEY"
         }
     ]
 }

--- a/python/alerts.py
+++ b/python/alerts.py
@@ -4,17 +4,31 @@
 import requests
 import json
 from discord import Webhook, RequestsWebhookAdapter
+import http.client, urllib
 
 class alert_module:
+
+    ALERT_CHANNEL_DISCORD = "discord"
+    ALERT_CHANNEL_PUSHOVER = "pushover"
+    ALERT_CHANNEL_NONE = "none"
+
     def __init__(self):
         configFile = '/config/config.json'
         with open(configFile,'r') as of:
             self.data = json.load(of)
     
-    def discord(self, alert_msg=""):
+    def send(self, alert_msg=""):
         alert_info = self.data['Alerts']
         for alert_data in alert_info:
-            if alert_data['Alerts-Enabled'] == True:
+            if alert_data['Alert-Channel'] == 'discord':
                 webhook = Webhook.from_url(alert_data['Discord-Webhook'], adapter=RequestsWebhookAdapter())
                 webhook.send(alert_msg)
-
+            elif alert_data['Alert-Channel'] == 'pushover':
+                webhook = http.client.HTTPSConnection("api.pushover.net:443")
+                webhook.request("POST", "/1/messages.json",
+                    urllib.parse.urlencode({
+                        "token": alert_data['Pushover-API-Token'],
+                        "user": alert_data['Pushover-User-Key'],
+                        "message": alert_msg,
+                    }), { "Content-type": "application/x-www-form-urlencoded" })
+                webhook.getresponse()

--- a/python/recurring-buy.py
+++ b/python/recurring-buy.py
@@ -10,7 +10,7 @@ import alerts
 if os.path.exists("/config/config.json"):
 
     general_settings = settings.settings()
-    alerts = alerts.alert_module()
+    alert = alerts.alert_module()
 
     api_settings = general_settings.api()
     schedule_settings = general_settings.schedule()
@@ -62,7 +62,7 @@ if os.path.exists("/config/config.json"):
             fund_amount = buy_total - current_funds
             fund_msg = "Your balance is %s %s, a deposit of %s %s will be made using your selected payment account." % (current_funds, currency, fund_amount, currency)
             print(fund_msg)
-            alerts.send(fund_msg)
+            alert.send(fund_msg)
             payment_id = get_funding_account(fund_amount, currency, fund_source)
             if payment_id == "Error":
                 error_msg = "Unable to determine payment method."
@@ -92,10 +92,9 @@ if os.path.exists("/config/config.json"):
             order_id = buy['id']
             order_details = auth_client.get_order(order_id=order_id)
             crypto_bought = order_details['filled_size']
-            # buy_completed = order_details['done_at']
             buy_message = "You bought %s of %s" % (crypto_bought, buy_pair)
             print(buy_message)
-            alerts.send(buy_message)
+            alert.send(buy_message)
 
     def recurring_buy():
 
@@ -122,43 +121,42 @@ if os.path.exists("/config/config.json"):
                 result = add_funds(buy_total, current_funds, max_fund, fund_source, currency)
                 if result[0] == "Error":
                     print(result[1])
-                    alerts.send(result[1])
+                    alert.send(result[1])
                 elif result[0] == "Success":
                     init_buy(crypto_settings, currency)
                 else:
                     fund_msg = "Something went wrong attempting to add funds to your account."
                     print(fund_msg)
-                    alerts.send(fund_msg)
+                    alert.send(fund_msg)
             elif enable_funding != True:
                 funding_msg = "Unable to complete your Coinbase Pro purchase.\n\
 Insufficient funds to make purchase and Auto-Funding is not enabled.\n\
 Please deposit at least %s %s into your account" % (buy_total, currency)
                 print(funding_msg)
-                alerts.send(funding_msg)
-                # print("Please deposit at least %s %s into your account" % (buy_total, currency))       
+                alert.send(funding_msg)
     
     if run_every == "seconds":
         # Run every X seconds (mainly for testing purposes)
         startupMsg = "Recurring Buy Bot Started!\nSchedule set for every %s seconds" % (repeat_time)
         schedule.every(repeat_time).seconds.do(recurring_buy)
         print(startupMsg)
-        alerts.send(startupMsg)
+        alert.send(startupMsg)
     elif run_every == "days":
         # Run every X days at specified run time
         startupMsg = "Recurring Buy Bot Started!\nSchedule set for every %s days at %s" % (repeat_time, run_time)
         schedule.every(repeat_time).days.at(run_time).do(recurring_buy)
         print(startupMsg)
-        alerts.send(startupMsg)
+        alert.send(startupMsg)
     elif run_every == "weekday":
         # Run every specified weekday at run time
         startupMsg = "Recurring Buy Bot Started!\nSchedule set for every %s at %s" % (run_day, run_time)
         getattr(schedule.every(), run_day).at(run_time).do(recurring_buy)
         print(startupMsg)
-        alerts.send(startupMsg)
+        alert.send(startupMsg)
     else:
         startupMsg = "Unable to determine run type. Please check config..."
         print(startupMsg)
-        alerts.send(startupMsg)
+        alert.send(startupMsg)
     
 
     while True:

--- a/python/recurring-buy.py
+++ b/python/recurring-buy.py
@@ -5,12 +5,12 @@ import json
 import math
 import coinbasepro, schedule, time
 import settings
-import alerts as send_alert
+import alerts
 
 if os.path.exists("/config/config.json"):
 
     general_settings = settings.settings()
-    send_alert = send_alert.alert_module()
+    alerts = alerts.alert_module()
 
     api_settings = general_settings.api()
     schedule_settings = general_settings.schedule()
@@ -62,7 +62,7 @@ if os.path.exists("/config/config.json"):
             fund_amount = buy_total - current_funds
             fund_msg = "Your balance is %s %s, a deposit of %s %s will be made using your selected payment account." % (current_funds, currency, fund_amount, currency)
             print(fund_msg)
-            send_alert.discord(fund_msg)
+            alerts.send(fund_msg)
             payment_id = get_funding_account(fund_amount, currency, fund_source)
             if payment_id == "Error":
                 error_msg = "Unable to determine payment method."
@@ -95,7 +95,7 @@ if os.path.exists("/config/config.json"):
             # buy_completed = order_details['done_at']
             buy_message = "You bought %s of %s" % (crypto_bought, buy_pair)
             print(buy_message)
-            send_alert.discord(buy_message)
+            alerts.send(buy_message)
 
     def recurring_buy():
 
@@ -122,19 +122,19 @@ if os.path.exists("/config/config.json"):
                 result = add_funds(buy_total, current_funds, max_fund, fund_source, currency)
                 if result[0] == "Error":
                     print(result[1])
-                    send_alert.discord(result[1])
+                    alerts.send(result[1])
                 elif result[0] == "Success":
                     init_buy(crypto_settings, currency)
                 else:
                     fund_msg = "Something went wrong attempting to add funds to your account."
                     print(fund_msg)
-                    send_alert.discord(fund_msg)
+                    alerts.send(fund_msg)
             elif enable_funding != True:
                 funding_msg = "Unable to complete your Coinbase Pro purchase.\n\
 Insufficient funds to make purchase and Auto-Funding is not enabled.\n\
 Please deposit at least %s %s into your account" % (buy_total, currency)
                 print(funding_msg)
-                send_alert.discord(funding_msg)
+                alerts.send(funding_msg)
                 # print("Please deposit at least %s %s into your account" % (buy_total, currency))       
     
     if run_every == "seconds":
@@ -142,23 +142,23 @@ Please deposit at least %s %s into your account" % (buy_total, currency)
         startupMsg = "Recurring Buy Bot Started!\nSchedule set for every %s seconds" % (repeat_time)
         schedule.every(repeat_time).seconds.do(recurring_buy)
         print(startupMsg)
-        send_alert.discord(startupMsg)
+        alerts.send(startupMsg)
     elif run_every == "days":
         # Run every X days at specified run time
         startupMsg = "Recurring Buy Bot Started!\nSchedule set for every %s days at %s" % (repeat_time, run_time)
         schedule.every(repeat_time).days.at(run_time).do(recurring_buy)
         print(startupMsg)
-        send_alert.discord(startupMsg)
+        alerts.send(startupMsg)
     elif run_every == "weekday":
         # Run every specified weekday at run time
         startupMsg = "Recurring Buy Bot Started!\nSchedule set for every %s at %s" % (run_day, run_time)
         getattr(schedule.every(), run_day).at(run_time).do(recurring_buy)
         print(startupMsg)
-        send_alert.discord(startupMsg)
+        alerts.send(startupMsg)
     else:
         startupMsg = "Unable to determine run type. Please check config..."
         print(startupMsg)
-        send_alert.discord(startupMsg)
+        alerts.send(startupMsg)
     
 
     while True:


### PR DESCRIPTION
Hi!

I thought it was a good idea to allow for more alert channels, especially as I did not like the idea of logging crypto purchases in an online text chat... I chose Pushover as an additional channel which allows for push notifications. Please have a look and get back to me in case of any questions/suggestions. 

Thanks for the DCA bot, by the way ;-).

Best regards,
Sebastian

